### PR TITLE
Prepend @container rules with custom element name

### DIFF
--- a/src/style-transform.mjs
+++ b/src/style-transform.mjs
@@ -43,6 +43,9 @@ function processBlock({
       if (v.type === 'media') {
         changeRules(a[i].rules)
       }
+      if (v.type === 'container') {
+        changeRules(a[i].rules)
+      }
     })
   }
   changeRules(parsed.stylesheet?.rules)


### PR DESCRIPTION
Rules defined under container queries need their selectors prepended with the custom element name, just like rules defined in media queries 🕵🏻

Example rules in an SFC:
```css
.foo { display: inline; }
@container (query) {
  .foo { display: block; }
}
```

Transformed, before:
```css
my-element .foo { display: inline; }
@container (query) {
  .foo { display: block; }
}
```

Transformed, after:
```css
my-element .foo { display: inline; }
my-element @container (query) {
  .foo { display: block; }
}
```