### PR TITLE
Prepend @supports rules with custom element name

### DIFF
--- a/src/style-transform.mjs
+++ b/src/style-transform.mjs
@@ -14,11 +14,18 @@ export default function styleTransform(options) {
   }
 }
 
+// Certain rule blocks require `changeRules` to run recursively on their contents in order to
+// emit rulesets with custom element names prepended to the selector
+const recursiveTypes = [
+  'container',
+  'media',
+  'supports',
+]
+
 function processBlock({
   css = '',
   scopeTo = '',
   disabled = false,
-  instance = ''
 }) {
   if (disabled || !scopeTo) return css
   const parsed = cssParser.parse(css)
@@ -40,10 +47,7 @@ function processBlock({
           return out
         })
       }
-      if (v.type === 'media') {
-        changeRules(a[i].rules)
-      }
-      if (v.type === 'container') {
+      if (recursiveTypes.includes(v.type)) {
         changeRules(a[i].rules)
       }
     })
@@ -51,3 +55,4 @@ function processBlock({
   changeRules(parsed.stylesheet?.rules)
   return cssParser.stringify(parsed)
 }
+

--- a/test/unit/style-scope-test.mjs
+++ b/test/unit/style-scope-test.mjs
@@ -46,6 +46,57 @@ test('default component scoped in ssr context', (t) => {
   t.equal(expected,result,'basic SSR context')
 })
 
+test('@container rules scoped in ssr context', (t) => {
+  t.plan(1)
+
+  const block = `@container (min-inline-size: 48em) { div { background: blue; } }`
+  const result = transform({
+    tagName: 'my-tag',
+    context: 'markup',
+    raw: block
+  })
+  const expected = `@container (min-inline-size: 48em) {
+  my-tag div {
+    background: blue;
+  }
+}` 
+  t.equal(expected,result,'SSR context')
+})
+
+test('@media rules scoped in ssr context', (t) => {
+  t.plan(1)
+
+  const block = `@media (min-inline-size: 48em) { div { background: blue; } }`
+  const result = transform({
+    tagName: 'my-tag',
+    context: 'markup',
+    raw: block
+  })
+  const expected = `@media (min-inline-size: 48em) {
+  my-tag div {
+    background: blue;
+  }
+}` 
+  t.equal(expected,result,'SSR context')
+})
+
+test('@supports rules scoped in ssr context', (t) => {
+  t.plan(1)
+
+  const block = `@supports (display: block) { div { background: blue; } }`
+  const result = transform({
+    tagName: 'my-tag',
+    context: 'markup',
+    raw: block
+  })
+  const expected = `@supports (display: block) {
+  my-tag div {
+    background: blue;
+  }
+}` 
+  t.equal(expected,result,'SSR context')
+})
+
 test('default component scoped in template context', (t) => {
   t.plan(1)
 


### PR DESCRIPTION
As with #5, except for `@supports` blocks. DRY'd up the logic a bit as I expect we'll have other rule block types to support with this in the future. Also updated tests.